### PR TITLE
Add optional dtype to zeros function

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var x = zeros([64, 64], 'float32')
 var y = zeros( x.shape, x.dtype )
 ```
 
-If you find yourself frequently creating the same array over and over though, [typedarray-pool](https://github.com/mikolalysenko/typedarray-pool) may be a better option.
+If you find yourself frequently creating the same array over and over though, [ndarray-scratch](https://github.com/mikolalysenko/ndarray-scratch) may be a better option.
 
 ## Install
 Just use npm:

--- a/README.md
+++ b/README.md
@@ -11,15 +11,44 @@ var zeros = require("zeros")
 var x = zeros([64, 64])
 ```
 
+It also accepts an optional dtype as specified in the [ndarray](https://github.com/scijs/ndarray) docs. For example,
+```javascript
+//Creates a 64x64 ndarray over a float32array filled with 0
+var x = zeros([64, 64], 'float32')
+```
+
+This makes it easy to create an array with the same size and dtype as an existing array:
+```javascript
+var x = zeros([64, 64], 'float32')
+var y = zeros( x.shape, x.dtype )
+```
+
+If you find yourself frequently creating the same array over and over though, [typedarray-pool](https://github.com/mikolalysenko/typedarray-pool) may be a better option.
+
 ## Install
 Just use npm:
 
     npm install zeros
     
-### `require("zeros")(shape)`
+### `require("zeros")(shape[, dtype])`
 Creates an ndarray with the given shape that is initialized to zero
 
 * `shape` is the shape of the resulting array
+* `dtype` is the data type of the array to allocate.  Must be one of:
+  + `"array"`
+  + `"uint8"`
+  + `"uint16"`
+  + `"uint32"`
+  + `"int8"`
+  + `"int16"`
+  + `"int32"`
+  + `"float"`
+  + `"float32"`
+  + `"double"`
+  + `"float64"`
+  + `"data"`
+  + `"uint8_clamped"`
+  + `"buffer"`
 
 **Returns** An array which is initialized to 0
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ndarray": "~1.0.0"
   },
   "devDependencies": {
+    "tap": "~0.7.1",
     "tape": "~1.0.4"
   },
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,13 @@ test("ndarray zeros", function(t) {
   t.end()
 });
 
+test("ndarray native array zeros", function(t) {
+  var x = zeros([64,32], 'array')
+  t.true( Array.isArray(x.data) );
+  t.equals( x.dtype, "array")
+  t.end()
+})
+
 test("ndarray uint8 zeros", function(t) {
   var x = zeros([64,32], 'uint8')
   t.equals( x.dtype, "uint8")
@@ -67,14 +74,14 @@ test("ndarray uint8_clamped zeros", function(t) {
   t.end()
 })
 
-test("ndarray array zeros", function(t) {
-  var x = zeros([64,32], 'array')
-  t.equals( x.dtype, "array")
+test("ndarray array buffer zeros", function(t) {
+  var x = zeros([64,32], 'buffer')
+  t.equals( x.dtype, "generic")
   t.end()
 })
 
-test("ndarray array buffer zeros", function(t) {
-  var x = zeros([64,32], 'buffer')
+test("ndarray data zeros", function(t) {
+  var x = zeros([64,32], 'data')
   t.equals( x.dtype, "generic")
   t.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,8 @@
 var zeros = require("../zeros.js")
 
-require("tape")("ndarray zeros", function(t) {
+var test = require("tape");
+
+test("ndarray zeros", function(t) {
 
   var x = zeros([64,32])
   
@@ -8,5 +10,71 @@ require("tape")("ndarray zeros", function(t) {
   t.equals(x.size, 64*32)
   t.equals(x.dtype, "float64")
 
+  t.end()
+});
+
+test("ndarray uint8 zeros", function(t) {
+  var x = zeros([64,32], 'uint8')
+  t.equals( x.dtype, "uint8")
+  t.end()
+})
+
+test("ndarray uint16 zeros", function(t) {
+  var x = zeros([64,32], 'uint16')
+  t.equals( x.dtype, "uint16")
+  t.end()
+})
+
+test("ndarray uint32 zeros", function(t) {
+  var x = zeros([64,32], 'uint32')
+  t.equals( x.dtype, "uint32")
+  t.end()
+})
+
+test("ndarray int8 zeros", function(t) {
+  var x = zeros([64,32], 'int8')
+  t.equals( x.dtype, "int8")
+  t.end()
+})
+
+test("ndarray int16 zeros", function(t) {
+  var x = zeros([64,32], 'int16')
+  t.equals( x.dtype, "int16")
+  t.end()
+})
+
+test("ndarray int32 zeros", function(t) {
+  var x = zeros([64,32], 'int32')
+  t.equals( x.dtype, "int32")
+  t.end()
+})
+
+test("ndarray double zeros", function(t) {
+  var x = zeros([64,32], 'double')
+  t.equals( x.dtype, "float64")
+  t.end()
+})
+
+test("ndarray float zeros", function(t) {
+  var x = zeros([64,32], 'float')
+  t.equals( x.dtype, "float32")
+  t.end()
+})
+
+test("ndarray uint8_clamped zeros", function(t) {
+  var x = zeros([64,32], 'uint8_clamped')
+  t.equals( x.dtype, "uint8_clamped")
+  t.end()
+})
+
+test("ndarray array zeros", function(t) {
+  var x = zeros([64,32], 'array')
+  t.equals( x.dtype, "array")
+  t.end()
+})
+
+test("ndarray array buffer zeros", function(t) {
+  var x = zeros([64,32], 'buffer')
+  t.equals( x.dtype, "generic")
   t.end()
 })

--- a/zeros.js
+++ b/zeros.js
@@ -2,10 +2,43 @@
 
 var ndarray = require("ndarray")
 
-module.exports = function zeros(shape) {
-  var sz = 1
-  for(var i=0; i<shape.length; ++i) {
-    sz *= shape[i]
+function dtypeToType(dtype) {
+  switch(dtype) {
+    case 'uint8':
+      return Uint8Array;
+    case 'uint16':
+      return Uint16Array;
+    case 'uint32':
+      return Uint32Array;
+    case 'int8':
+      return Int8Array;
+    case 'int16':
+      return Int16Array;
+    case 'int32':
+      return Int32Array;
+    case 'float':
+    case 'float32':
+      return Float32Array;
+    case 'double':
+    case 'float64':
+      return Float64Array;
+    case 'uint8_clamped':
+      return Uint8ClampedArray;
+    case 'generic':
+    case 'buffer':
+    case 'data':
+    case 'dataview':
+      return ArrayBuffer;
+    case 'array':
+      return Array;
   }
-  return ndarray(new Float64Array(sz), shape)
+}
+
+module.exports = function zeros(shape, dtype) {
+  dtype = dtype || 'float64';
+  var sz = 1;
+  for(var i=0; i<shape.length; ++i) {
+    sz *= shape[i];
+  }
+  return ndarray(new (dtypeToType(dtype))(sz), shape);
 }


### PR DESCRIPTION
See: #1. Verbose but straightforward. Your style preferences may differ slightly, but the existing behavior is unchanged. There are some corner cases around `arraybuffer` vs `buffer` vs `generic` vs `data` that might benefit from consistent choices, but I don't think there's anything surprising here and the existing API is unchanged.
