### PR TITLE
Use dtype to detect type of array

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "dtype": "^1.0.0",
     "ndarray": "^1.0.16"
   },
   "devDependencies": {

--- a/zeros.js
+++ b/zeros.js
@@ -1,38 +1,7 @@
 "use strict"
 
 var ndarray = require("ndarray")
-
-function dtypeToType(dtype) {
-  switch(dtype) {
-    case 'uint8':
-      return Uint8Array;
-    case 'uint16':
-      return Uint16Array;
-    case 'uint32':
-      return Uint32Array;
-    case 'int8':
-      return Int8Array;
-    case 'int16':
-      return Int16Array;
-    case 'int32':
-      return Int32Array;
-    case 'float':
-    case 'float32':
-      return Float32Array;
-    case 'double':
-    case 'float64':
-      return Float64Array;
-    case 'uint8_clamped':
-      return Uint8ClampedArray;
-    case 'generic':
-    case 'buffer':
-    case 'data':
-    case 'dataview':
-      return ArrayBuffer;
-    case 'array':
-      return Array;
-  }
-}
+var dtypeToType = require("dtype")
 
 module.exports = function zeros(shape, dtype) {
   dtype = dtype || 'float64';


### PR DESCRIPTION
`dtype@1.0.0` is now compatible with all the types ndarray uses: https://github.com/shama/dtype/blob/master/index.js

Thanks!
